### PR TITLE
Non-constant time memory comparison fix

### DIFF
--- a/TRAINRATA/scripts/tmp-build/wrapper.c
+++ b/TRAINRATA/scripts/tmp-build/wrapper.c
@@ -247,7 +247,7 @@ __attribute__((section(".do_mac.lib"))) inline void my_memcpy(uint8_t* dst, uint
   for(i=0; i<size; i++) dst[i] = src[i];
 }
 
-int secure_memcmp(const uint8_t* s1, const uint8_t* s2, int size);
+int cst_memeq(const uint8_t* x, const uint8_t* y, int size);
 
 
 #pragma vector = UART_RX_VECTOR
@@ -385,7 +385,7 @@ __attribute__((section(".do_mac.lib"))) void read_byte()
         hash((uint8_t *)hash_res, (uint8_t *)input_hash, (uint32_t)SIZE_HASH);
         memcpy(input_hash, hash_res, SIZE_HASH);
       }
-      if (secure_memcmp(hash_res, cur_hash, SIZE_HASH) != 0)
+      if (cst_memeq(hash_res, cur_hash, SIZE_HASH) != 0)
       {
         return;
       }
@@ -497,14 +497,14 @@ __attribute__ ((section (".do_mac.call"))) void Hacl_HMAC_SHA2_256_hmac_entry()
   uint8_t key[64] = {0};
   uint8_t verification[32] = {0};
 
-  if (secure_memcmp((uint8_t*) MAC_ADDR, (uint8_t*) CTR_ADDR, 32) > 0) 
+  if (memcmp((uint8_t*) MAC_ADDR, (uint8_t*) CTR_ADDR, 32) > 0) 
   {
     //Copy the key from KEY_ADDR to the key buffer.
     memcpy(key, (uint8_t*) KEY_ADDR, 64);
     hmac((uint8_t*) verification, (uint8_t*) key, (uint32_t) 64, (uint8_t*)MAC_ADDR, (uint32_t) 32);
 
     // Verifier Authentication before calling HMAC
-    if (secure_memcmp((uint8_t*) VRF_AUTH, verification, 32) == 0) 
+    if (cst_memeq((uint8_t*) VRF_AUTH, verification, 32) == 0) 
     {
       // Update the counter with the current authenticated challenge.
       memcpy((uint8_t*) CTR_ADDR, (uint8_t*) MAC_ADDR, 32);    
@@ -531,23 +531,18 @@ __attribute__ ((section (".do_mac.call"))) void Hacl_HMAC_SHA2_256_hmac_entry()
   __asm__ volatile( "br      #__mac_leave" "\n\t");
 }
 
+inline __attribute__((section (".do_mac.body")))
+int cst_memeq(const uint8_t* x, const uint8_t* y, int size)
+{
+    volatile unsigned int d = 0U;
+    unsigned int i;
 
-__attribute__ ((section (".do_mac.body"))) int secure_memcmp(const uint8_t* s1, const uint8_t* s2, int size) {
-    int res = 0;
-    int first = 1;
-    for(int i = 0; i < size; i++) {
-      if (first == 1 && s1[i] > s2[i]) {
-        res = 1;
-        first = 0;
-      }
-      else if (first == 1 && s1[i] < s2[i]) {
-        res = -1;
-        first = 0;
-      }
+    for (i = 0; i < size; i++) {
+        d |= x[i] ^ y[i];
     }
-    return res;
-}
 
+    return (1 & ((d - 1) >> 8)) - 1;
+}
 
 __attribute__ ((section (".do_mac.leave"))) __attribute__((naked)) void Hacl_HMAC_SHA2_256_hmac_exit() 
 {

--- a/TRAINRATA/train/sw-att/wrapper.c
+++ b/TRAINRATA/train/sw-att/wrapper.c
@@ -247,7 +247,6 @@ __attribute__((section(".do_mac.lib"))) inline void my_memcpy(uint8_t* dst, uint
   for(i=0; i<size; i++) dst[i] = src[i];
 }
 
-int secure_memcmp(const uint8_t* s1, const uint8_t* s2, int size);
 int cst_memeq(const uint8_t* x, const uint8_t* y, int size);
 
 
@@ -498,7 +497,7 @@ __attribute__ ((section (".do_mac.call"))) void Hacl_HMAC_SHA2_256_hmac_entry()
   uint8_t key[64] = {0};
   uint8_t verification[32] = {0};
 
-  if (secure_memcmp((uint8_t*) MAC_ADDR, (uint8_t*) CTR_ADDR, 32) > 0) 
+  if (memcmp((uint8_t*) MAC_ADDR, (uint8_t*) CTR_ADDR, 32) > 0) 
   {
     //Copy the key from KEY_ADDR to the key buffer.
     memcpy(key, (uint8_t*) KEY_ADDR, 64);
@@ -530,23 +529,6 @@ __attribute__ ((section (".do_mac.call"))) void Hacl_HMAC_SHA2_256_hmac_entry()
   __asm__ volatile("add     #96,    r1" "\n\t");
   //__asm__ volatile("pop     r11" "\n\t");
   __asm__ volatile( "br      #__mac_leave" "\n\t");
-}
-
-
-__attribute__ ((section (".do_mac.body"))) int secure_memcmp(const uint8_t* s1, const uint8_t* s2, int size) {
-    int res = 0;
-    int first = 1;
-    for(int i = 0; i < size; i++) {
-      if (first == 1 && s1[i] > s2[i]) {
-        res = 1;
-        first = 0;
-      }
-      else if (first == 1 && s1[i] < s2[i]) {
-        res = -1;
-        first = 0;
-      }
-    }
-    return res;
 }
 
 inline __attribute__((section (".do_mac.body")))

--- a/TRAINRATA/train/sw-att/wrapper.c
+++ b/TRAINRATA/train/sw-att/wrapper.c
@@ -248,6 +248,7 @@ __attribute__((section(".do_mac.lib"))) inline void my_memcpy(uint8_t* dst, uint
 }
 
 int secure_memcmp(const uint8_t* s1, const uint8_t* s2, int size);
+int cst_memeq(const uint8_t* x, const uint8_t* y, int size);
 
 
 #pragma vector = UART_RX_VECTOR
@@ -385,7 +386,7 @@ __attribute__((section(".do_mac.lib"))) void read_byte()
         hash((uint8_t *)hash_res, (uint8_t *)input_hash, (uint32_t)SIZE_HASH);
         memcpy(input_hash, hash_res, SIZE_HASH);
       }
-      if (secure_memcmp(hash_res, cur_hash, SIZE_HASH) != 0)
+      if (cst_memeq(hash_res, cur_hash, SIZE_HASH) != 0)
       {
         return;
       }
@@ -504,7 +505,7 @@ __attribute__ ((section (".do_mac.call"))) void Hacl_HMAC_SHA2_256_hmac_entry()
     hmac((uint8_t*) verification, (uint8_t*) key, (uint32_t) 64, (uint8_t*)MAC_ADDR, (uint32_t) 32);
 
     // Verifier Authentication before calling HMAC
-    if (secure_memcmp((uint8_t*) VRF_AUTH, verification, 32) == 0) 
+    if (cst_memeq((uint8_t*) VRF_AUTH, verification, 32) == 0) 
     {
       // Update the counter with the current authenticated challenge.
       memcpy((uint8_t*) CTR_ADDR, (uint8_t*) MAC_ADDR, 32);    
@@ -548,6 +549,18 @@ __attribute__ ((section (".do_mac.body"))) int secure_memcmp(const uint8_t* s1, 
     return res;
 }
 
+inline __attribute__((section (".do_mac.body")))
+int cst_memeq(const uint8_t* x, const uint8_t* y, int size)
+{
+    volatile unsigned int d = 0U;
+    unsigned int i;
+
+    for (i = 0; i < size; i++) {
+        d |= x[i] ^ y[i];
+    }
+
+    return (1 & ((d - 1) >> 8)) - 1;
+}
 
 __attribute__ ((section (".do_mac.leave"))) __attribute__((naked)) void Hacl_HMAC_SHA2_256_hmac_exit() 
 {


### PR DESCRIPTION
As mentioned in issue #1 we have replaced the vulnerable secure_memcmp with the constant-time version of libsodium. Notice that in some cases memcmp is used instead of secure_memcmp, which is used for checking whether one buffer is larger and is in our opinion not security-critical. In the other case, where timing matters, libsodium's memequal is used to check for tag equality. However, we did not manage to install all the dependencies so we did not run extensive tests on this implementation.

Kind regards
Ruben, @martonbognar and @jovanbulck 